### PR TITLE
Add KPI search functionality

### DIFF
--- a/src/api/searchKPIs.ts
+++ b/src/api/searchKPIs.ts
@@ -1,0 +1,31 @@
+import { MetricCard } from "../types";
+import { fetchAllAvailableKPIs } from "./browseKPIs";
+import { fetchFollowedKPIs } from "./followedKPIs";
+
+export const searchKPIs = async (query: string): Promise<MetricCard[]> => {
+  const [followed, browse] = await Promise.all([
+    fetchFollowedKPIs(),
+    fetchAllAvailableKPIs(),
+  ]);
+
+  const lower = query.toLowerCase().trim();
+  const uniqueMap = new Map<string, MetricCard>();
+  [...followed, ...browse].forEach((kpi) => {
+    if (!uniqueMap.has(kpi.title)) {
+      uniqueMap.set(kpi.title, kpi);
+    }
+  });
+
+  const all = Array.from(uniqueMap.values());
+  const results = all.filter((kpi) =>
+    kpi.title.toLowerCase().includes(lower)
+  );
+
+  results.sort(
+    (a, b) =>
+      a.title.toLowerCase().indexOf(lower) -
+      b.title.toLowerCase().indexOf(lower)
+  );
+
+  return results;
+};

--- a/src/components/common/GlobalSearchBar.tsx
+++ b/src/components/common/GlobalSearchBar.tsx
@@ -1,10 +1,19 @@
 // /src/components/common/GlobalSearchBar.tsx
 
-import React from "react";
+import React, { useState } from "react";
 import { View, TextInput, Platform } from "react-native";
 import { Feather } from "@expo/vector-icons";
+import { useNavigation } from "@react-navigation/native";
 
 const GlobalSearchBar = () => {
+  const [query, setQuery] = useState("");
+  const navigation = useNavigation<any>();
+
+  const handleSubmit = () => {
+    if (!query.trim()) return;
+    navigation.navigate("SearchResults", { query });
+  };
+
   return (
     <View className="flex-row items-center rounded-full border border-gray-300 bg-white px-4 py-2 shadow-sm w-[240px]">
       <Feather
@@ -19,6 +28,10 @@ const GlobalSearchBar = () => {
         className="flex-1 text-sm text-black outline-none"
         autoCapitalize="none"
         autoCorrect={false}
+        value={query}
+        onChangeText={setQuery}
+        onSubmitEditing={handleSubmit}
+        returnKeyType="search"
         style={Platform.select({
           web: { outlineStyle: "none" }, // <-- Remove browser outline on web
         })}

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -15,6 +15,7 @@ import { useAppDispatch, useAppSelector } from "../redux/hooks";
 import { validateToken } from "../redux/slices/tokenSlice";
 import AuthenticatedLayout from "../layouts/AuthenticatedLayout";
 import BrowseMetricsScreen from "../screens/BrowseMetricsScreen";
+import SearchResultsScreen from "../screens/SearchResultsScreen";
 
 const Stack = createNativeStackNavigator();
 
@@ -60,6 +61,13 @@ const AppNavigator = () => {
             {() => (
               <AuthenticatedLayout>
                 <BrowseMetricsScreen />
+              </AuthenticatedLayout>
+            )}
+          </Stack.Screen>
+          <Stack.Screen name="SearchResults">
+            {() => (
+              <AuthenticatedLayout>
+                <SearchResultsScreen />
               </AuthenticatedLayout>
             )}
           </Stack.Screen>

--- a/src/screens/HomePage.tsx
+++ b/src/screens/HomePage.tsx
@@ -17,9 +17,9 @@ const HomePage = () => {
   return (
     <ScrollView className="bg-white px-4 py-6">
       <View className="container mx-auto">
-        {/* Today's Pulse block */}
+        {/* Today&apos;s Pulse block */}
         <View className={isWide ? "w-full md:w-1/2 pr-4 mb-6" : "mb-6"}>
-          <Text className="text-2xl font-semibold mb-1">Today's Pulse</Text>
+          <Text className="text-2xl font-semibold mb-1">Today&apos;s Pulse</Text>
           <Text className="text-xs text-gray-500 mb-3">
             Last updated about 3 hours ago
           </Text>

--- a/src/screens/SearchResultsScreen.tsx
+++ b/src/screens/SearchResultsScreen.tsx
@@ -1,0 +1,41 @@
+// /src/screens/SearchResultsScreen.tsx
+
+import React, { useEffect, useState } from "react";
+import { ScrollView, Text, View, useWindowDimensions } from "react-native";
+import { useRoute } from "@react-navigation/native";
+import { MetricCard } from "../types";
+import MetricCardList from "../components/MetricCardList";
+import { searchKPIs } from "../api/searchKPIs";
+
+const SearchResultsScreen = () => {
+  const route = useRoute();
+  const { query } = route.params as { query: string };
+  const { width } = useWindowDimensions();
+  const isWide = width >= 768;
+  const [data, setData] = useState<MetricCard[] | null>(null);
+
+  useEffect(() => {
+    const fetch = async () => {
+      const result = await searchKPIs(query);
+      setData(result);
+    };
+    fetch();
+  }, [query]);
+
+  return (
+    <ScrollView className="bg-white px-4 py-6">
+      <View className="container mx-auto">
+        <Text className="text-2xl font-semibold mb-3">
+          Results for &apos;{query}&apos;
+        </Text>
+        {data && data.length === 0 ? (
+          <Text>No results found.</Text>
+        ) : (
+          <MetricCardList data={data} isGrid={isWide} />
+        )}
+      </View>
+    </ScrollView>
+  );
+};
+
+export default SearchResultsScreen;


### PR DESCRIPTION
## Summary
- implement KPI search API
- wire search bar to navigate to results
- create search results screen
- register search route in navigation
- fix lint issue in HomePage

## Testing
- `npm run lint`
- `npx tsc --noEmit` *(fails: object literals not assignable)*

------
https://chatgpt.com/codex/tasks/task_e_68404e20ec2c8323b7df38a26763f166