### PR TITLE
Implement browse card follow feature

### DIFF
--- a/src/components/BrowseCards/BrowseCardItem.tsx
+++ b/src/components/BrowseCards/BrowseCardItem.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { View, TouchableOpacity } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import Card from '../Card';
+import { MetricCard } from '../../types';
+
+interface Props {
+  metric: MetricCard;
+  onAddToFollowing: (metric: MetricCard) => void;
+}
+
+const BrowseCardItem: React.FC<Props> = ({ metric, onAddToFollowing }) => {
+  return (
+    <View className="relative">
+      <TouchableOpacity
+        onPress={() => onAddToFollowing(metric)}
+        className="absolute right-2 top-2 z-10 bg-white rounded-full p-1"
+      >
+        <Feather name="plus" size={20} color="#2563eb" />
+      </TouchableOpacity>
+      <Card {...metric} />
+    </View>
+  );
+};
+
+export default BrowseCardItem;

--- a/src/components/FollowingCards.tsx
+++ b/src/components/FollowingCards.tsx
@@ -1,10 +1,8 @@
 // /src/components/FollowingCards.tsx
 
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { useSelector } from "react-redux";
 import { RootState } from "../redux/store";
-import { MetricCard } from "../types";
-import { fetchFollowedKPIs } from "../api/followedKPIs";
 import MetricCardList from "./MetricCardList";
 
 type FollowingCardsProps = {
@@ -12,16 +10,7 @@ type FollowingCardsProps = {
 };
 
 const FollowingCards: React.FC<FollowingCardsProps> = ({ isGrid = false }) => {
-  const metrics = useSelector((state: RootState) => state.kpi.data);
-  const [data, setData] = useState<MetricCard[] | null>(metrics);
-
-  useEffect(() => {
-    const fetch = async () => {
-      const result = await fetchFollowedKPIs();
-      setData(result);
-    };
-    fetch();
-  }, []);
+  const data = useSelector((state: RootState) => state.following.data);
 
   return <MetricCardList data={data} isGrid={isGrid} />;
 };

--- a/src/components/MetricCardList.tsx
+++ b/src/components/MetricCardList.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import { Text, View } from "react-native";
 import Card from "./Card";
+import BrowseCardItem from "./BrowseCards/BrowseCardItem";
 import { MetricCard } from "../types";
 
 type Props = {
@@ -24,12 +25,15 @@ const MetricCardList: React.FC<Props> = ({ data, isGrid = false, onAdd, showAdd 
       }
     >
       {data.map((metric, index) => (
-        <Card
-          key={index}
-          {...metric}
-          showAdd={showAdd}
-          onAdd={() => onAdd && onAdd(metric)}
-        />
+        showAdd ? (
+          <BrowseCardItem
+            key={index}
+            metric={metric}
+            onAddToFollowing={() => onAdd && onAdd(metric)}
+          />
+        ) : (
+          <Card key={index} {...metric} />
+        )
       ))}
     </View>
   );

--- a/src/redux/slices/browseSlice.ts
+++ b/src/redux/slices/browseSlice.ts
@@ -1,0 +1,24 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { MetricCard } from '../../types';
+import { browseMetricsData } from '../../mock/mockBrowseKPIs';
+
+interface BrowseState {
+  data: MetricCard[];
+}
+
+const initialState: BrowseState = {
+  data: browseMetricsData,
+};
+
+const browseSlice = createSlice({
+  name: 'browse',
+  initialState,
+  reducers: {
+    removeCardFromBrowse: (state, action: PayloadAction<string>) => {
+      state.data = state.data.filter((card) => card.title !== action.payload);
+    },
+  },
+});
+
+export const { removeCardFromBrowse } = browseSlice.actions;
+export default browseSlice.reducer;

--- a/src/redux/slices/followingSlice.ts
+++ b/src/redux/slices/followingSlice.ts
@@ -1,0 +1,26 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { MetricCard } from '../../types';
+import { metricsData } from '../../mock/mockFollowedKPIs';
+
+interface FollowingState {
+  data: MetricCard[];
+}
+
+const initialState: FollowingState = {
+  data: metricsData,
+};
+
+const followingSlice = createSlice({
+  name: 'following',
+  initialState,
+  reducers: {
+    addCardToFollowing: (state, action: PayloadAction<MetricCard>) => {
+      if (!state.data.some((card) => card.title === action.payload.title)) {
+        state.data.push(action.payload);
+      }
+    },
+  },
+});
+
+export const { addCardToFollowing } = followingSlice.actions;
+export default followingSlice.reducer;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -4,12 +4,16 @@ import { configureStore } from "@reduxjs/toolkit";
 import kpiReducer from "./slices/kpiSlice";
 import authReducer from "./slices/authSlice";
 import tokenReducer from "./slices/tokenSlice";
+import browseReducer from "./slices/browseSlice";
+import followingReducer from "./slices/followingSlice";
 
 const store = configureStore({
   reducer: {
     kpi: kpiReducer,
     auth: authReducer,
     tokenStatus: tokenReducer,
+    browse: browseReducer,
+    following: followingReducer,
   },
 });
 

--- a/src/screens/BrowseMetricsScreen.tsx
+++ b/src/screens/BrowseMetricsScreen.tsx
@@ -1,31 +1,25 @@
 // /src/screens/BrowseMetricsScreen.tsx
 
-import React, { useEffect, useState } from "react";
-import { ScrollView, Text, View, useWindowDimensions, Alert } from "react-native";
-import { MetricCard } from "../types";
-import { fetchAllAvailableKPIs, removeKPIFromBrowse } from "../api/browseKPIs";
-import { addKPIToFollowed } from "../api/followedKPIs";
+import React from "react";
+import { ScrollView, Text, View, useWindowDimensions } from "react-native";
+import { useAppDispatch, useAppSelector } from "../redux/hooks";
+import { addCardToFollowing } from "../redux/slices/followingSlice";
+import { removeCardFromBrowse } from "../redux/slices/browseSlice";
 import MetricCardList from "../components/MetricCardList";
+import { MetricCard } from "../types";
+import { showToast } from "../utils/notifications";
 
 const BrowseMetricsScreen = () => {
   const { width } = useWindowDimensions();
   const isWide = width >= 768;
-  const [data, setData] = useState<MetricCard[] | null>(null);
+  const dispatch = useAppDispatch();
+  const data = useAppSelector((state) => state.browse.data);
 
-  const handleAdd = async (metric: MetricCard) => {
-    await addKPIToFollowed(metric);
-    await removeKPIFromBrowse(metric.title);
-    setData((prev) => prev?.filter((m) => m.title !== metric.title) || null);
-    Alert.alert("Card added to your following");
+  const handleAdd = (metric: MetricCard) => {
+    dispatch(addCardToFollowing(metric));
+    dispatch(removeCardFromBrowse(metric.title));
+    showToast("Card added to your following");
   };
-
-  useEffect(() => {
-    const fetch = async () => {
-      const result = await fetchAllAvailableKPIs();
-      setData(result);
-    };
-    fetch();
-  }, []);
 
   return (
     <ScrollView className="bg-white px-4 py-6">

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -1,0 +1,9 @@
+import { Platform, ToastAndroid, Alert } from 'react-native';
+
+export const showToast = (message: string) => {
+  if (Platform.OS === 'android') {
+    ToastAndroid.show(message, ToastAndroid.SHORT);
+  } else {
+    Alert.alert(message);
+  }
+};


### PR DESCRIPTION
## Summary
- add `BrowseCardItem` component with `+` button
- manage browse and following cards in new Redux slices
- handle card additions in `BrowseMetricsScreen`
- use Redux following list in `FollowingCards`
- expose toast notification utility
- update store and metric card list

## Testing
- `npm run lint`
- `npx tsc --noEmit` *(fails: Argument type mismatch and style issues)*

------
https://chatgpt.com/codex/tasks/task_e_68405b4da14c832387c7ade0e5f844d6